### PR TITLE
Move rxmd binary out of src

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,9 @@ default:
 all:
 	cd init && $(MAKE)
 	cd src && $(MAKE)
-	ln -s src/rxmd rxmd
 
 rxmd:
 	cd src && $(MAKE)
-	ln -s src/rxmd rxmd
 
 init:
 	cd init && $(MAKE)

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,11 @@ default:
 all:
 	cd init && $(MAKE)
 	cd src && $(MAKE)
+	ln -s src/rxmd rxmd
 
 rxmd:
 	cd src && $(MAKE)
+	ln -s src/rxmd rxmd
 
 init:
 	cd init && $(MAKE)

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,9 +13,8 @@ OBJS := $(SRCS:.F90=.o)
 EXE := rxmd
 
 
-$(EXE): $(OBJS)
-	$(MPIF90) $(MPIF90_FLAGS) -o $(EXE) $(OBJS) module.o $(LIBS)
-	mv $(EXE) ../$(EXE)
+../$(EXE): $(OBJS)
+	$(MPIF90) $(MPIF90_FLAGS) -o ../$(EXE) $(OBJS) module.o $(LIBS)
 
 $(OBJS) : base.mod
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,7 @@ EXE := rxmd
 
 $(EXE): $(OBJS)
 	$(MPIF90) $(MPIF90_FLAGS) -o $(EXE)  $(OBJS) module.o $(LIBS)
-	mv $(EXE) ../$(EXE)
+	ln -s src/$(EXE) ../$(EXE)
 
 $(OBJS) : base.mod
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,7 @@ EXE := rxmd
 
 $(EXE): $(OBJS)
 	$(MPIF90) $(MPIF90_FLAGS) -o $(EXE) $(OBJS) module.o $(LIBS)
-	ln -s src/$(EXE) ../$(EXE)
+	if [ ! -h ../$(EXE) ] ; then ln -s src/$(EXE) ../$(EXE) ; fi
 
 $(OBJS) : base.mod
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,7 +39,7 @@ init.o : fileio.o
 main.o : init.o
 
 clean:
-	rm -f PI* *.o *.mod *.MOD mpif.h ../rxmd
+	rm -f PI* *.o *.mod *.MOD mpif.h ../rxmd rxmd
 
 rebuild:
 	make clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,7 @@ EXE := rxmd
 
 $(EXE): $(OBJS)
 	$(MPIF90) $(MPIF90_FLAGS) -o $(EXE) $(OBJS) module.o $(LIBS)
-	if [ ! -h ../$(EXE) ] ; then ln -s src/$(EXE) ../$(EXE) ; fi
+	mv $(EXE) ../$(EXE)
 
 $(OBJS) : base.mod
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ include ../make.inc
 # suffix rules
 .SUFFIXES: .o .F90 .cpp
 .F90.o:
-	$(MPIF90) $(MPIF90_FLAGS) $(LIBS) -c $<
+	$(MPIF90) $(MPIF90_FLAGS) -c $<
 
 %.o: %.mod
 
@@ -14,13 +14,13 @@ EXE := rxmd
 
 
 $(EXE): $(OBJS)
-	$(MPIF90) $(MPIF90_FLAGS) -o $(EXE)  $(OBJS) module.o $(LIBS)
+	$(MPIF90) $(MPIF90_FLAGS) -o $(EXE) $(OBJS) module.o $(LIBS)
 	ln -s src/$(EXE) ../$(EXE)
 
 $(OBJS) : base.mod
 
 base.mod: module.F90
-	$(MPIF90) $(MPIF90_FLAGS) -c  module.F90
+	$(MPIF90) $(MPIF90_FLAGS) -c module.F90
 
 main.F90 : cg.mod
 


### PR DESCRIPTION
Added softlink inside Makefile for rxmd  executable inside src directory from the home directory