### PR TITLE
Getnonbon qeq

### DIFF
--- a/src/main.F90
+++ b/src/main.F90
@@ -463,14 +463,14 @@ do c3=0, nbcc(3)-1
                packed_coordinates(m_size,:) = pos(j,1:3)
             end if
             if (m_size == max_pack) then
-               call cal_packed_neighbor(m_size,max_pack,pos(i,1:3),packed_coordinates,packed_indices, nbplist(:,i))
+               call calc_packed_neighbor(m_size,max_pack,pos(i,1:3),packed_coordinates,packed_indices, nbplist(:,i))
                m_size = 0
             end if
             j=nbllist(j)
          enddo
        enddo
        if (m_size > 0) then
-          call cal_packed_neighbor(m_size,max_pack,pos(i,1:3),packed_coordinates,packed_indices, nbplist(:,i))
+          call calc_packed_neighbor(m_size,max_pack,pos(i,1:3),packed_coordinates,packed_indices, nbplist(:,i))
           m_size = 0
        end if
       i=nbllist(i)
@@ -484,7 +484,7 @@ it_timer(15)=it_timer(15)+(tj-ti)
 end subroutine
 
 !----------------------------------------------------------------------
-subroutine  cal_packed_neighbor(m_size, max_pack, posi, packed_coordinates, packed_indices, nbplist_i)
+subroutine  calc_packed_neighbor(m_size, max_pack, posi, packed_coordinates, packed_indices, nbplist_i)
 use atoms; use parameters
 !----------------------------------------------------------------------
 
@@ -494,14 +494,16 @@ integer, intent(in) :: m_size, max_pack
 real(8), intent(in) :: packed_coordinates(1:max_pack,3)  ! contains the atomic coordinates of the packed neighbor
 integer, intent(in) :: packed_indices(1:max_pack)
 integer, intent(inout) :: nbplist_i(0:MAXNEIGHBS10)
-real(8) :: dr2(1:max_pack), dr(3)                 ! contanins distance for the entire batch of packed atoms
+real(8) :: dr2(1:max_pack), dr(3)  ! contanins distance square for the entire batch of packed atoms to the reference atom
 integer :: i_pack, i_counter
 
+! compute distance square
 do i_pack = 1, m_size
    dr(1:3) = posi(1:3) - packed_coordinates(i_pack,1:3)
    dr2(i_pack) = sum(dr(1:3)*dr(1:3))
 end do
 
+! construct neighbour list
 i_counter = nbplist_i(0)
 do i_pack = 1, m_size
    if (dr2(i_pack) <= rctap2) then

--- a/src/main.F90
+++ b/src/main.F90
@@ -431,20 +431,19 @@ real(8) :: dr(3), dr2
 integer :: ti,tj,tk
 
 integer :: m_size=0                ! keep track of the size of the packed_indices and packed_coordinates
-integer,parameter :: max_pack=256  ! maximum packing size for packing neighborlist
+integer, parameter :: max_pack = 256  ! maximum packing size for packing neighborlist
 integer :: packed_indices(1:max_pack)   ! contains the indicies of the neighbor for each atom
-!integer :: neighbor_index(1:max_pack)   !  contains the indicies of the neighbor with greater then cutoff distance
 real(8) :: packed_coordinates(1:max_pack,3)  ! contains the atomic coordinates og the packed neighbor
 
 call system_clock(ti,tk)
 
 ! reset non-bonding pair list
-nbplist(0,:)=0
+nbplist(0,:) = 0
 
 !$omp parallel do default(shared),private(c1,c2,c3,c4,c5,c6,i,j,m,n,mn,iid,jid,m_size,packed_indices,packed_coordinates)
-do c1=0, nbcc(1)-1
-do c2=0, nbcc(2)-1
-do c3=0, nbcc(3)-1
+do c1 = 0, nbcc(1)-1
+do c2 = 0, nbcc(2)-1
+do c3 = 0, nbcc(3)-1
 
    i = nbheader(c1,c2,c3)
    do m = 1, nbnacell(c1,c2,c3)
@@ -456,24 +455,24 @@ do c3=0, nbcc(3)-1
          c6 = c3 + nbmesh(3,mn)
 
          j = nbheader(c4,c5,c6)
-         do n=1, nbnacell(c4,c5,c6)
-            if(i/=j) then
-               m_size = m_size+1
+         do n = 1, nbnacell(c4,c5,c6)
+            if (i /= j) then
+               m_size = m_size + 1
                packed_indices(m_size) = j
-               packed_coordinates(m_size,:) = pos(j,1:3)
+               packed_coordinates(m_size,:) = pos(j, 1:3)
             end if
             if (m_size == max_pack) then
-               call calc_packed_neighbor(m_size,max_pack,pos(i,1:3),packed_coordinates,packed_indices, nbplist(:,i))
+               call calc_packed_neighbor(m_size, max_pack, pos(i,1:3), packed_coordinates, packed_indices, nbplist(:,i))
                m_size = 0
             end if
-            j=nbllist(j)
+            j = nbllist(j)
          enddo
        enddo
        if (m_size > 0) then
-          call calc_packed_neighbor(m_size,max_pack,pos(i,1:3),packed_coordinates,packed_indices, nbplist(:,i))
+          call calc_packed_neighbor(m_size, max_pack, pos(i,1:3), packed_coordinates, packed_indices, nbplist(:,i))
           m_size = 0
        end if
-      i=nbllist(i)
+      i = nbllist(i)
    enddo
 enddo; enddo; enddo
 !$omp end parallel do

--- a/src/main.F90
+++ b/src/main.F90
@@ -463,14 +463,14 @@ do c3=0, nbcc(3)-1
                packed_coordinates(m_size,:) = pos(j,1:3)
             end if
             if (m_size == max_pack) then
-               call cal_packed_neighbor(m_size,max_pack,pos(i,1:3),packed_coordinates,packed_indices)
+               call cal_packed_neighbor(m_size,max_pack,pos(i,1:3),i,packed_coordinates,packed_indices)
                m_size = 0
             end if
             j=nbllist(j)
          enddo
        enddo
        if (m_size > 0) then
-          call cal_packed_neighbor(m_size,max_pack,pos,packed_coordinates,packed_indices)
+          call cal_packed_neighbor(m_size,max_pack,pos(i,1:3),i,packed_coordinates,packed_indices)
           m_size = 0
        end if
       i=nbllist(i)
@@ -484,12 +484,13 @@ it_timer(15)=it_timer(15)+(tj-ti)
 end subroutine
 
 !----------------------------------------------------------------------
-subroutine  cal_packed_neighbor(m_size,max_pack,posi,packed_coordinates,packed_indices)
+subroutine  cal_packed_neighbor(m_size,max_pack,posi,ival,packed_coordinates,packed_indices)
 use atoms; use parameters
 !----------------------------------------------------------------------
 
+implicit None
 real(8),intent(in) :: posi(3)
-integer,intent(in) :: m_size,max_pack
+integer,intent(in) :: m_size,max_pack,ival
 real(8),intent(in) :: packed_coordinates(1:max_pack,3)  ! contains the atomic coordinates of the packed neighbor
 integer,intent(in) :: packed_indices(1:max_pack)
 real(8) :: dpr(1:max_pack,3),dr                 ! contanins distance for the entire batch of packed atoms
@@ -504,8 +505,8 @@ do i_pack=1,m_size
    dr = sum(dpr(i_pack,1:3)*dpr(i_pack,1:3))
    ! neighbor_index = pack(packed_indices,mask=(dpr(i_pack,4) <=rctap2))
    if (dr <=rctap2) then
-       nbplist(0,i)=nbplist(0,i)+1
-       nbplist(nbplist(0,i),i)= packed_indices(i_pack)
+       nbplist(0,ival)=nbplist(0,ival)+1
+       nbplist(nbplist(0,ival),ival)= packed_indices(i_pack)
    end if
 end do
 

--- a/src/main.F90
+++ b/src/main.F90
@@ -464,14 +464,14 @@ do c3=0, nbcc(3)-1
                packed_coordinates(m_size,:) = pos(j,1:3)
             end if
             if (m_size == max_pack) then
-               call cal_packed_neighbor(i_pack,m_size,max_pack,dpr,pos,packed_coordinates)
+               call cal_packed_neighbor(i_pack,m_size,max_pack,dpr,pos,packed_coordinates,packed_indices)
                m_size = 0
             end if
             j=nbllist(j)
          enddo
        enddo
        if (m_size > 0) then
-          call cal_packed_neighbor(i_pack,m_size,max_pack,dpr,pos,packed_coordinates)
+          call cal_packed_neighbor(i_pack,m_size,max_pack,dpr,pos,packed_coordinates,packed_indices)
           m_size = 0
        end if
       i=nbllist(i)
@@ -485,7 +485,7 @@ it_timer(15)=it_timer(15)+(tj-ti)
 end subroutine
 
 !----------------------------------------------------------------------
-subroutine  cal_packed_neighbor(i_pack,m_size,max_pack,dpr,pos,packed_coordinates)
+subroutine  cal_packed_neighbor(i_pack,m_size,max_pack,dpr,pos,packed_coordinates,packed_indices)
 use atoms; use parameters
 !----------------------------------------------------------------------
 
@@ -493,6 +493,7 @@ real(8),intent(in) :: pos(NBUFFER,3)
 integer :: i_pack,m_size
 real(8) :: dpr(1:max_pack,4)            ! contanins distance for the entire batch of packed atoms
 real(8) :: packed_coordinates(1:max_pack,3)  ! contains the atomic coordinates of the packed neighbor
+integer :: packed_indices(1:max_pack)
 
 do i_pack=1,m_size
    dpr(i_pack,1:3) = pos(i,1:3) - packed_coordinates(i_pack,1:3)
@@ -501,7 +502,7 @@ end do
 
 do i_pack=1,m_size
    ! neighbor_index = pack(packed_indices,mask=(dpr(i_pack,4) <=rctap2))
-   if (dpr(:,4) <=rctap2) then
+   if (dpr(i_pack,4) <=rctap2) then
        nbplist(0,i)=nbplist(0,i)+1
        nbplist(nbplist(0,i),i)= packed_indices(i_pack)
    end if

--- a/src/main.F90
+++ b/src/main.F90
@@ -430,15 +430,20 @@ real(8) :: dr(3), dr2
 
 integer :: ti,tj,tk
 
-integer :: tt,max_pack=256,m_size=0
-integer :: temp_array(1:256)
+integer :: p_counter               ! counter used druing packing neighborlist
+integer :: m_size=0                ! keep track of the size of the packed_indices and packed_coordinates
+integer,parameter :: max_pack=256  ! maximum packing size for packing neighborlist
+integer :: packed_indices(1:max_pack)   ! contains the indicies of the neighbor for each atom
+integer :: neighbor_index(1:max_pack)   !  contains the indicies of the neighbor with greater then cutoff distance
+real(8) :: dpr(1:max_pack,4)            ! contanins distance for the entire batch of packed atoms
+real(8) :: packed_coordinates(1:max_pack,3)  ! contains the atomic coordinates og the packed neighbor
 
 call system_clock(ti,tk)
 
 ! reset non-bonding pair list
 nbplist(0,:)=0
 
-!$omp parallel do default(shared),private(c1,c2,c3,c4,c5,c6,i,j,m,n,mn,iid,jid,dr,dr2,m_size,temp_array,tt)
+!$omp parallel do default(shared),private(c1,c2,c3,c4,c5,c6,i,j,m,n,mn,iid,jid,dr,dr2,m_size,packed_indices,packed_coordinates,neighbor_index,dpr,p_counter)
 do c1=0, nbcc(1)-1
 do c2=0, nbcc(2)-1
 do c3=0, nbcc(3)-1
@@ -456,33 +461,42 @@ do c3=0, nbcc(3)-1
          do n=1, nbnacell(c4,c5,c6)
             if(i/=j) then
                m_size = m_size+1
-               temp_array(m_size) = j
+               packed_indices(m_size) = j
+               packed_coordinates(m_size,:) = pos(j,1:3)
             end if
             if (m_size == max_pack) then
-               do tt=1,max_pack
-                  j = temp_array(tt)
-                  dr(1:3) = pos(i,1:3) - pos(j,1:3)
-                  dr2 = sum(dr(1:3)*dr(1:3))
-                  if (dr2<=rctap2) then
+               dpr(:,1) = pos(i,1) - packed_coordinates(:,1)
+               dpr(:,2) = pos(i,2) - packed_coordinates(:,2)
+               dpr(:,3) = pos(i,3) - packed_coordinates(:,3)
+               dpr(:,4) = dpr(:,1)*dpr(:,1) + dpr(:,2)*dpr(:,2) + dpr(:,3)*dpr(:,3)
+               neighbor_index(:) = -1
+               neighbor_index = pack(packed_indices,mask=(dpr(:,4) <=rctap2))
+               p_counter = 1
+               do while (neighbor_index(p_counter) > -1)
                      nbplist(0,i)=nbplist(0,i)+1
-                     nbplist(nbplist(0,i),i)=j
-                  end if
-               end do
+                     nbplist(nbplist(0,i),i)=neighbor_index(p_counter)
+                     p_counter = p_counter+1
+                enddo
                m_size = 0
             end if
             j=nbllist(j)
          enddo
        enddo
-       do tt=1,m_size
-          j = temp_array(tt)
-          dr(1:3) = pos(i,1:3) - pos(j,1:3)
-          dr2 = sum(dr(1:3)*dr(1:3))
-          if (dr2<=rctap2) then
-             nbplist(0,i)=nbplist(0,i)+1
-             nbplist(nbplist(0,i),i)=j
-          end if
+       if (m_size > 0) then
+          dpr(1:m_size,1) = pos(i,1) - packed_coordinates(1:m_size,1)
+          dpr(1:m_size,2) = pos(i,2) - packed_coordinates(1:m_size,2)
+          dpr(1:m_size,3) = pos(i,3) - packed_coordinates(1:m_size,3)
+          dpr(1:m_size,4) = dpr(1:m_size,1)*dpr(1:m_size,1) + dpr(1:m_size,2)*dpr(1:m_size,2) + dpr(1:m_size,3)*dpr(1:m_size,3)
+          neighbor_index(:) = -1
+          neighbor_index(1:m_size) = pack(packed_indices,mask=(dpr(1:m_size,4) <=rctap2))
+          p_counter = 1
+          do while (neighbor_index(p_counter) > -1)
+                nbplist(0,i)=nbplist(0,i)+1
+                 nbplist(nbplist(0,i),i)=neighbor_index(p_counter)
+                 p_counter = p_counter+1
+          end do
           m_size = 0
-       end do
+       end if
       i=nbllist(i)
    enddo
 enddo; enddo; enddo

--- a/src/main.F90
+++ b/src/main.F90
@@ -463,14 +463,14 @@ do c3=0, nbcc(3)-1
                packed_coordinates(m_size,:) = pos(j,1:3)
             end if
             if (m_size == max_pack) then
-               call cal_packed_neighbor(m_size,max_pack,pos(i,1:3),i,packed_coordinates,packed_indices)
+               call cal_packed_neighbor(m_size,max_pack,pos(i,1:3),packed_coordinates,packed_indices, nbplist(:,i))
                m_size = 0
             end if
             j=nbllist(j)
          enddo
        enddo
        if (m_size > 0) then
-          call cal_packed_neighbor(m_size,max_pack,pos(i,1:3),i,packed_coordinates,packed_indices)
+          call cal_packed_neighbor(m_size,max_pack,pos(i,1:3),packed_coordinates,packed_indices, nbplist(:,i))
           m_size = 0
        end if
       i=nbllist(i)
@@ -484,15 +484,16 @@ it_timer(15)=it_timer(15)+(tj-ti)
 end subroutine
 
 !----------------------------------------------------------------------
-subroutine  cal_packed_neighbor(m_size,max_pack,posi,ival,packed_coordinates,packed_indices)
+subroutine  cal_packed_neighbor(m_size, max_pack, posi, packed_coordinates, packed_indices, nbplist_i)
 use atoms; use parameters
 !----------------------------------------------------------------------
 
 implicit None
-real(8),intent(in) :: posi(3)
-integer,intent(in) :: m_size,max_pack,ival
-real(8),intent(in) :: packed_coordinates(1:max_pack,3)  ! contains the atomic coordinates of the packed neighbor
-integer,intent(in) :: packed_indices(1:max_pack)
+real(8), intent(in) :: posi(3)
+integer, intent(in) :: m_size, max_pack
+real(8), intent(in) :: packed_coordinates(1:max_pack,3)  ! contains the atomic coordinates of the packed neighbor
+integer, intent(in) :: packed_indices(1:max_pack)
+integer, intent(inout) :: nbplist_i(0:MAXNEIGHBS10)
 real(8) :: dpr(1:max_pack,3),dr                 ! contanins distance for the entire batch of packed atoms
 integer :: i_pack
 
@@ -505,8 +506,8 @@ do i_pack=1,m_size
    dr = sum(dpr(i_pack,1:3)*dpr(i_pack,1:3))
    ! neighbor_index = pack(packed_indices,mask=(dpr(i_pack,4) <=rctap2))
    if (dr <=rctap2) then
-       nbplist(0,ival)=nbplist(0,ival)+1
-       nbplist(nbplist(0,ival),ival)= packed_indices(i_pack)
+       nbplist_i(0)=nbplist_i(0)+1
+       nbplist_i(nbplist_i(0))= packed_indices(i_pack)
    end if
 end do
 

--- a/src/main.F90
+++ b/src/main.F90
@@ -438,7 +438,7 @@ real(8) :: packed_coordinates(1:max_pack,3)  ! contains the atomic coordinates o
 call system_clock(ti,tk)
 
 ! reset non-bonding pair list
-nbplist(0,:) = 0
+!nbplist(0,:) = 0
 
 !$omp parallel do default(shared),private(c1,c2,c3,c4,c5,c6,i,j,m,n,mn,m_size,packed_indices,packed_coordinates)
 do c1 = 0, nbcc(1)-1
@@ -449,6 +449,7 @@ do c3 = 0, nbcc(3)-1
    do m = 1, nbnacell(c1,c2,c3)
       
       m_size = 0
+      nbplist(0,i) = 0
       do mn = 1, nbnmesh
          c4 = c1 + nbmesh(1,mn)
          c5 = c2 + nbmesh(2,mn)

--- a/src/main.F90
+++ b/src/main.F90
@@ -424,7 +424,7 @@ implicit none
 
 real(8),intent(in) :: pos(NBUFFER,3)
 
-integer :: c1,c2,c3,c4,c5,c6,i,j,m,n,mn,iid,jid
+integer :: c1,c2,c3,c4,c5,c6,i,j,m,n,mn
 integer :: l2g
 real(8) :: dr(3), dr2
 
@@ -440,7 +440,7 @@ call system_clock(ti,tk)
 ! reset non-bonding pair list
 nbplist(0,:) = 0
 
-!$omp parallel do default(shared),private(c1,c2,c3,c4,c5,c6,i,j,m,n,mn,iid,jid,m_size,packed_indices,packed_coordinates)
+!$omp parallel do default(shared),private(c1,c2,c3,c4,c5,c6,i,j,m,n,mn,m_size,packed_indices,packed_coordinates)
 do c1 = 0, nbcc(1)-1
 do c2 = 0, nbcc(2)-1
 do c3 = 0, nbcc(3)-1

--- a/src/main.F90
+++ b/src/main.F90
@@ -494,22 +494,22 @@ integer, intent(in) :: m_size, max_pack
 real(8), intent(in) :: packed_coordinates(1:max_pack,3)  ! contains the atomic coordinates of the packed neighbor
 integer, intent(in) :: packed_indices(1:max_pack)
 integer, intent(inout) :: nbplist_i(0:MAXNEIGHBS10)
-real(8) :: dpr(1:max_pack,3),dr                 ! contanins distance for the entire batch of packed atoms
-integer :: i_pack
+real(8) :: dr2(1:max_pack), dr(3)                 ! contanins distance for the entire batch of packed atoms
+integer :: i_pack, i_counter
 
-do i_pack=1,m_size
-   dpr(i_pack,1:3) = posi(1:3) - packed_coordinates(i_pack,1:3)
-!   dpr(i_pack,4) = sum(dpr(i_pack,1:3)*dpr(i_pack,1:3))
+do i_pack = 1, m_size
+   dr(1:3) = posi(1:3) - packed_coordinates(i_pack,1:3)
+   dr2(i_pack) = sum(dr(1:3)*dr(1:3))
 end do
 
-do i_pack=1,m_size
-   dr = sum(dpr(i_pack,1:3)*dpr(i_pack,1:3))
-   ! neighbor_index = pack(packed_indices,mask=(dpr(i_pack,4) <=rctap2))
-   if (dr <=rctap2) then
-       nbplist_i(0)=nbplist_i(0)+1
-       nbplist_i(nbplist_i(0))= packed_indices(i_pack)
+i_counter = nbplist_i(0)
+do i_pack = 1, m_size
+   if (dr2(i_pack) <= rctap2) then
+       i_counter = i_counter + 1
+       nbplist_i(i_counter) = packed_indices(i_pack)
    end if
 end do
+nbplist_i(0) = i_counter
 
 end subroutine
 

--- a/src/qeq.F90
+++ b/src/qeq.F90
@@ -186,7 +186,7 @@ use atoms; use parameters; use MemoryAllocator
 ! <nbrlist> and <hessian> will be used for different purpose later.
 !-----------------------------------------------------------------------------------------------------------------------
 implicit none
-integer :: i,j, ity, jty, n, m, mn, nn,h_ind
+integer :: i,j, ity, jty, n, m, mn, nn
 integer :: c1,c2,c3, c4,c5,c6
 real(4) :: dr2
 real(8) :: dr(3), drtb
@@ -203,7 +203,7 @@ call system_clock(ti,tk)
 
 
 !$omp parallel do schedule(runtime), default(shared), &
-!$omp private(i,j,ity,jty,n,m,mn,nn,c1,c2,c3,c4,c5,c6,dr,dr2,drtb,itb,inxn,m_size,packed_indices,packed_coordinates,h_ind)
+!$omp private(i,j,ity,jty,n,m,mn,nn,c1,c2,c3,c4,c5,c6,dr,dr2,drtb,itb,inxn,m_size,packed_indices,packed_coordinates)
 do c1=0, nbcc(1)-1
 do c2=0, nbcc(2)-1
 do c3=0, nbcc(3)-1
@@ -213,7 +213,8 @@ do c3=0, nbcc(3)-1
 
    ity=nint(atype(i))
    nbplist(0,i) = 0
-
+   
+   m_size = 0
    do mn = 1, nbnmesh
       c4 = c1 + nbmesh(1,mn)
       c5 = c2 + nbmesh(2,mn)
@@ -222,34 +223,22 @@ do c3=0, nbcc(3)-1
       j = nbheader(c4,c5,c6)
       do n=1, nbnacell(c4,c5,c6)
 
-         if(i/=j) then
+         if (i/=j) then
             m_size = m_size + 1
             packed_indices(m_size) = j
             packed_coordinates(m_size,:) = pos(j, 1:3)
          end if
          if (m_size == max_pack) then
-            call calc_packed_neighbor(m_size, max_pack, pos(i,1:3),packed_coordinates, packed_indices, nbplist(:,i))
+            call calc_packed_neighbor_qeq(ity,i,m_size, max_pack, pos(i,1:3), packed_coordinates, packed_indices, nbplist(:,i))
             m_size = 0
-         end if 
+         end if
          j=nbllist(j)
       enddo
    enddo !   do mn = 1, nbnmesh
    if (m_size > 0) then
-      call calc_packed_neighbor(m_size, max_pack, pos(i,1:3),packed_coordinates, packed_indices, nbplist(:,i))
+      call calc_packed_neighbor_qeq(ity,i,m_size, max_pack, pos(i,1:3), packed_coordinates, packed_indices, nbplist(:,i))
       m_size = 0
    end if
-    
-   do h_ind=1,nbplist(0,i)
-      j = nbplist(h_ind,i)
-      jty = nint(atype(j))
-      dr(1:3) = pos(i,1:3) - pos(j,1:3)
-      dr2 = sum(dr(1:3)*dr(1:3))
-      itb = int(dr2*UDRi)
-      drtb = dr2 - itb*UDR
-      drtb = drtb*UDRi
-      inxn = inxn2(ity, jty)
-      hessian(h_ind,i) = (1.d0-drtb)*TBL_Eclmb_QEq(itb,inxn) + drtb*TBL_Eclmb_QEq(itb+1,inxn)
-   end do
    if (nbplist(0,i) > MAXNEIGHBS10) then
       write(6,*) "ERROR: In qeq.F90 inside qeq_initialize, nbplist greater then MAXNEIGHBS10 on mpirank",myid, &
                  "with value",nbplist(0,i)
@@ -272,7 +261,6 @@ it_timer(16)=it_timer(16)+(tj-ti)
 
 end subroutine 
 
-<<<<<<< HEAD
 
 !----------------------------------------------------------------------
 subroutine  calc_packed_neighbor_qeq(ity,i_val,m_size, max_pack, posi, packed_coordinates, packed_indices, nbplist_i)
@@ -317,8 +305,6 @@ nbplist_i(0) = i_counter
 
 end subroutine
 
-=======
->>>>>>> 2fa76c7f41844bc3262272de1ed0add75e7f7c5c
 !-----------------------------------------------------------------------------------------------------------------------
 subroutine get_hsh(Est,hshs_sum,hsht_sum)
 use atoms; use parameters

--- a/src/qeq.F90
+++ b/src/qeq.F90
@@ -298,7 +298,7 @@ do i_pack = 1, m_size
        drtb = dr2(i_pack) - itb*UDR
        drtb = drtb*UDRi
        inxn = inxn2(ity, jty)
-       hessian(packed_indices(i_pack),i_val) = (1.d0-drtb)*TBL_Eclmb_QEq(itb,inxn) + drtb*TBL_Eclmb_QEq(itb+1,inxn)
+       hessian(i_counter,i_val) = (1.d0-drtb)*TBL_Eclmb_QEq(itb,inxn) + drtb*TBL_Eclmb_QEq(itb+1,inxn)
    end if
 end do
 nbplist_i(0) = i_counter

--- a/src/qeq.F90
+++ b/src/qeq.F90
@@ -194,11 +194,16 @@ integer :: itb, inxn
 
 integer :: ti,tj,tk
 
+integer :: m_size=0                ! keep track of the size of the packed_indices and packed_coordinates
+integer, parameter :: max_pack = 256  ! maximum packing size for packing neighborlist
+integer :: packed_indices(1:max_pack)   ! contains the indicies of the neighbor for each atom
+real(8) :: packed_coordinates(1:max_pack,3)  ! contains the atomic coordinates og the packed neighbor
+
 call system_clock(ti,tk)
 
 
 !$omp parallel do schedule(runtime), default(shared), &
-!$omp private(i,j,ity,jty,n,m,mn,nn,c1,c2,c3,c4,c5,c6,dr,dr2,drtb,itb,inxn)
+!$omp private(i,j,ity,jty,n,m,mn,nn,c1,c2,c3,c4,c5,c6,dr,dr2,drtb,itb,inxn,m_size,packed_indices,packed_coordinates)
 do c1=0, nbcc(1)-1
 do c2=0, nbcc(2)-1
 do c3=0, nbcc(3)-1
@@ -208,7 +213,8 @@ do c3=0, nbcc(3)-1
 
    ity=nint(atype(i))
    nbplist(0,i) = 0
-
+   
+   m_size = 0
    do mn = 1, nbnmesh
       c4 = c1 + nbmesh(1,mn)
       c5 = c2 + nbmesh(2,mn)
@@ -217,34 +223,22 @@ do c3=0, nbcc(3)-1
       j = nbheader(c4,c5,c6)
       do n=1, nbnacell(c4,c5,c6)
 
-         if(i/=j) then
-            dr(1:3) = pos(i,1:3) - pos(j,1:3)
-            dr2 =  sum(dr(1:3)*dr(1:3))
-
-            if(dr2 < rctap2) then
-
-               jty = nint(atype(j))
-
-!--- make a neighbor list with cutoff length = 10[A]
-!$omp atomic
-               nbplist(0,i) = nbplist(0,i) + 1
-               nbplist(nbplist(0,i),i) = j
-
-!--- get table index and residual value
-               itb = int(dr2*UDRi)
-               drtb = dr2 - itb*UDR
-               drtb = drtb*UDRi
-
-               inxn = inxn2(ity, jty)
-
-               hessian(nbplist(0,i),i) = (1.d0-drtb)*TBL_Eclmb_QEq(itb,inxn) + drtb*TBL_Eclmb_QEq(itb+1,inxn)
-            endif
-         endif
-
+         if (i/=j) then
+            m_size = m_size + 1
+            packed_indices(m_size) = j
+            packed_coordinates(m_size,:) = pos(j, 1:3)
+         end if
+         if (m_size == max_pack) then
+            call calc_packed_neighbor_qeq(ity,i,m_size, max_pack, pos(i,1:3), packed_coordinates, packed_indices, nbplist(:,i))
+            m_size = 0
+         end if
          j=nbllist(j)
       enddo
    enddo !   do mn = 1, nbnmesh
-
+   if (m_size > 0) then
+      call calc_packed_neighbor_qeq(ity,i,m_size, max_pack, pos(i,1:3), packed_coordinates, packed_indices, nbplist(:,i))
+      m_size = 0
+   end if
    if (nbplist(0,i) > MAXNEIGHBS10) then
       write(6,*) "ERROR: In qeq.F90 inside qeq_initialize, nbplist greater then MAXNEIGHBS10 on mpirank",myid, &
                  "with value",nbplist(0,i)
@@ -266,6 +260,50 @@ call system_clock(tj,tk)
 it_timer(16)=it_timer(16)+(tj-ti)
 
 end subroutine 
+
+
+!----------------------------------------------------------------------
+subroutine  calc_packed_neighbor_qeq(ity,i_val,m_size, max_pack, posi, packed_coordinates, packed_indices, nbplist_i)
+use atoms; use parameters
+!----------------------------------------------------------------------
+
+implicit None
+real(8), intent(in) :: posi(3)
+integer, intent(in) :: m_size, max_pack
+real(8), intent(in) :: packed_coordinates(1:max_pack,3)  ! contains the atomic coordinates of the packed neighbor
+integer, intent(in) :: packed_indices(1:max_pack)
+integer, intent(inout) :: nbplist_i(0:MAXNEIGHBS10)
+real(8) :: dr2(1:max_pack), dr(3)  ! contanins distance square for the entire batch of packed atoms to the reference atom
+real(8) ::  drtb
+integer :: i_pack, i_counter
+
+integer, intent(in) :: ity,i_val
+integer :: jty,itb, inxn
+
+! compute distance square
+do i_pack = 1, m_size
+   dr(1:3) = posi(1:3) - packed_coordinates(i_pack,1:3)
+   dr2(i_pack) = sum(dr(1:3)*dr(1:3))
+end do
+
+! construct neighbour list
+i_counter = nbplist_i(0)
+do i_pack = 1, m_size
+   if (dr2(i_pack) <= rctap2) then
+       i_counter = i_counter + 1
+       nbplist_i(i_counter) = packed_indices(i_pack)
+       !--- get table index and residual value
+       jty = nint(atype(packed_indices(i_pack)))
+       itb = int(dr2(i_pack)*UDRi)
+       drtb = dr2(i_pack) - itb*UDR
+       drtb = drtb*UDRi
+       inxn = inxn2(ity, jty)
+       hessian(packed_indices(i_pack),i_val) = (1.d0-drtb)*TBL_Eclmb_QEq(itb,inxn) + drtb*TBL_Eclmb_QEq(itb+1,inxn)
+   end if
+end do
+nbplist_i(0) = i_counter
+
+end subroutine
 
 !-----------------------------------------------------------------------------------------------------------------------
 subroutine get_hsh(Est,hshs_sum,hsht_sum)


### PR DESCRIPTION
Updated the Non-Bonding Calculation in main.F90 (subroutine GetNonbondingPairList) and qeq.F90(subroutine qeq_initialize).

In Both of these subroutine, instead of computing neighbor list  sequentially, its been updated to first make packed array of size 256 and then using this array compute the neighbor list.

subroutine  calc_packed_neighbor in main.F90 subroutine  calc_packed_neighbor_qeq in qeq.F90 does this calculations for for GetNonbondingPairList and qeq_initialize respectively.

