### PR TITLE
Automatically add missing definitions for rxmdtorch

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(rxmd ${src_rxmd})
 target_link_libraries(rxmd PUBLIC mpi_wrapper)
 if(RXMD_ENABLE_TORCH)
   target_link_libraries(rxmd PUBLIC torch_rxmd)
+  target_compile_definitions(rxmd PUBLIC RXMDNN)
 endif()
 
 add_executable(rxmd_exe main.F90)


### PR DESCRIPTION
Provide definitions for `#ifdef RXMDNN` in [rxmdnn.F90](https://github.com/USCCACS/RXMD/blob/56ad575dd0d32b98b19681c3edc559e078034731/src/rxmdnn.F90#L44)

closes #57 since this should handle any missing initializations.